### PR TITLE
Patch/v2.0.6

### DIFF
--- a/paystack.php
+++ b/paystack.php
@@ -4,7 +4,7 @@ Plugin Name: Paystack Add-On for Gravity Forms
 Plugin URI: https://paystack.com/docs/libraries-and-plugins/plugins#wordpress
 0
 Description: Integrates Gravity Forms with Paystack, enabling customers to pay for goods and services through Gravity Forms.
-Version: 2.0.4
+Version: 2.0.6
 Author: Paystack
 Author URI: https://developers.paystack.com
 License: GPL-2.0+
@@ -31,7 +31,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 defined('ABSPATH') || die();
 
-define('GF_PAYSTACK_VERSION', '2.0.4');
+define('GF_PAYSTACK_VERSION', '2.0.6');
 
 add_action('gform_loaded', array('GF_Paystack_Bootstrap', 'load'), 5);
 

--- a/paystack.php
+++ b/paystack.php
@@ -4,7 +4,7 @@ Plugin Name: Paystack Add-On for Gravity Forms
 Plugin URI: https://paystack.com/docs/libraries-and-plugins/plugins#wordpress
 0
 Description: Integrates Gravity Forms with Paystack, enabling customers to pay for goods and services through Gravity Forms.
-Version: 2.0.1
+Version: 2.0.4
 Author: Paystack
 Author URI: https://developers.paystack.com
 License: GPL-2.0+
@@ -31,7 +31,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 defined('ABSPATH') || die();
 
-define('GF_PAYSTACK_VERSION', '2.0.1');
+define('GF_PAYSTACK_VERSION', '2.0.4');
 
 add_action('gform_loaded', array('GF_Paystack_Bootstrap', 'load'), 5);
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 5.1
 
 Tested up to: 6.6
 Requires PHP: 7.2 and higher
-Stable tag: 2.0.4
+Stable tag: 2.0.6
 
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -56,7 +56,7 @@ Yes you can! Join in on our [GitHub repository](https://github.com/PaystackHQ/pl
 
 == Changelog ==
 
-= 2.0.4 - AUGUST 8, 2024 =
+= 2.0.6 - AUGUST 8, 2024 =
 * Compatibility with WordPress v6.6 and PHP 8.2
 
 = 2.0.3 - SEPTMBER 26, 2023 =
@@ -84,7 +84,7 @@ Yes you can! Join in on our [GitHub repository](https://github.com/PaystackHQ/pl
 
 == Upgrade Notice ==
 
-= 2.0.3 =
+= 2.0.6 =
 * Compatibility with WordPress v6.6 and PHP 8.2
 
 = 2.0.2 =


### PR DESCRIPTION
Updated Compatibility with WordPress v6.6 and PHP 8.2 & the plugin version number to 2.0.6